### PR TITLE
Use secureRender to fix CSP problems with new magento

### DIFF
--- a/Block/Matomo.php
+++ b/Block/Matomo.php
@@ -49,6 +49,8 @@ class Matomo extends \Magento\Framework\View\Element\Template
      */
     protected $_dataHelper = null;
 
+    protected \Magento\Csp\Helper\CspNonceProvider $_cspNonceProvider;
+
     /**
      * Constructor
      *
@@ -56,6 +58,7 @@ class Matomo extends \Magento\Framework\View\Element\Template
      * @param \Magento\Framework\Json\EncoderInterface $jsonEncoder
      * @param \Chessio\Matomo\Model\Tracker $tracker
      * @param \Chessio\Matomo\Helper\Data $dataHelper
+     * @param \Magento\Csp\Helper\CspNonceProvider $cspNonceProvider
      * @param array $data
      */
     public function __construct(
@@ -63,11 +66,13 @@ class Matomo extends \Magento\Framework\View\Element\Template
         \Magento\Framework\Json\EncoderInterface $jsonEncoder,
         \Chessio\Matomo\Model\Tracker $tracker,
         \Chessio\Matomo\Helper\Data $dataHelper,
+        \Magento\Csp\Helper\CspNonceProvider $cspNonceProvider,
         array $data = []
     ) {
         $this->_jsonEncoder = $jsonEncoder;
         $this->_tracker = $tracker;
         $this->_dataHelper = $dataHelper;
+        $this->_cspNonceProvider = $cspNonceProvider;
         parent::__construct($context, $data);
     }
 
@@ -116,7 +121,8 @@ class Matomo extends \Magento\Framework\View\Element\Template
             'scriptUrl'  => $this->getScriptUrl(),
             'trackerUrl' => $this->getTrackerUrl(),
             'siteId'     => $this->getSiteId(),
-            'actions'    => $this->getTracker()->toArray()
+            'actions'    => $this->getTracker()->toArray(),
+            'nonce'      => $this->_cspNonceProvider->generateNonce(),
         ];
     }
 

--- a/Block/Matomo.php
+++ b/Block/Matomo.php
@@ -49,8 +49,6 @@ class Matomo extends \Magento\Framework\View\Element\Template
      */
     protected $_dataHelper = null;
 
-    protected \Magento\Csp\Helper\CspNonceProvider $_cspNonceProvider;
-
     /**
      * Constructor
      *
@@ -58,7 +56,7 @@ class Matomo extends \Magento\Framework\View\Element\Template
      * @param \Magento\Framework\Json\EncoderInterface $jsonEncoder
      * @param \Chessio\Matomo\Model\Tracker $tracker
      * @param \Chessio\Matomo\Helper\Data $dataHelper
-     * @param \Magento\Csp\Helper\CspNonceProvider $cspNonceProvider
+     * @param \Magento\Csp\Helper\CspNonceProvider $_cspNonceProvider
      * @param array $data
      */
     public function __construct(
@@ -66,13 +64,12 @@ class Matomo extends \Magento\Framework\View\Element\Template
         \Magento\Framework\Json\EncoderInterface $jsonEncoder,
         \Chessio\Matomo\Model\Tracker $tracker,
         \Chessio\Matomo\Helper\Data $dataHelper,
-        \Magento\Csp\Helper\CspNonceProvider $cspNonceProvider,
+        protected \Magento\Csp\Helper\CspNonceProvider $_cspNonceProvider,
         array $data = []
     ) {
         $this->_jsonEncoder = $jsonEncoder;
         $this->_tracker = $tracker;
         $this->_dataHelper = $dataHelper;
-        $this->_cspNonceProvider = $cspNonceProvider;
         parent::__construct($context, $data);
     }
 
@@ -174,10 +171,9 @@ class Matomo extends \Magento\Framework\View\Element\Template
     /**
      * Encode data to a JSON string
      *
-     * @param mixed $data
      * @return string
      */
-    public function jsonEncode($data)
+    public function jsonEncode(mixed $data)
     {
         return $this->_jsonEncoder->encode($data);
     }
@@ -187,6 +183,7 @@ class Matomo extends \Magento\Framework\View\Element\Template
      *
      * @return string
      */
+    #[\Override]
     protected function _toHtml()
     {
         if ($this->_dataHelper->isTrackingEnabled()) {

--- a/Helper/Tracker.php
+++ b/Helper/Tracker.php
@@ -108,7 +108,7 @@ class Tracker extends \Magento\Framework\App\Helper\AbstractHelper
 
         // Push `addEcommerceItem'
         foreach ($matomoItems as $matomoItem) {
-            list($sku, $name, $rowTotal, $qty) = $matomoItem;
+            [$sku, $name, $rowTotal, $qty] = $matomoItem;
 
             $tracker->addEcommerceItem(
                 $sku,
@@ -123,7 +123,7 @@ class Tracker extends \Magento\Framework\App\Helper\AbstractHelper
 
         // Push `trackEcommerceOrder'
         if (!empty($matomoOrder)) {
-            list($orderId, $grandTotal, $subTotal, $tax, $shipping, $discount)
+            [$orderId, $grandTotal, $subTotal, $tax, $shipping, $discount]
                 = $matomoOrder;
 
             $tracker->trackEcommerceOrder(

--- a/Model/Config/Source/UserId/Provider.php
+++ b/Model/Config/Source/UserId/Provider.php
@@ -50,6 +50,7 @@ class Provider implements \Magento\Framework\Option\ArrayInterface
      *
      * @return array
      */
+    #[\Override]
     public function toOptionArray()
     {
         $options = [['value' => '', 'label' => __('No')]];

--- a/Model/Tracker.php
+++ b/Model/Tracker.php
@@ -326,7 +326,7 @@ class Tracker
     public function __call($name, $arguments)
     {
         return $this->push($this->_actionFactory->create([
-            'name' => $name,
+            '_name' => $name,
             'args' => $arguments
         ]));
     }

--- a/Model/Tracker/Action.php
+++ b/Model/Tracker/Action.php
@@ -29,13 +29,6 @@ class Action
 {
 
     /**
-     * Action name
-     *
-     * @var string $_name
-     */
-    protected $_name;
-
-    /**
      * Action arguments
      *
      * @var array $_args
@@ -45,12 +38,14 @@ class Action
     /**
      * Constructor
      *
-     * @param string $name
+     * @param string $_name
      * @param array $args
      */
-    public function __construct($name, array $args = [])
+    public function __construct(/**
+     * Action name
+     */
+    protected $_name, array $args = [])
     {
-        $this->_name = $name;
         $this->_args = $args;
     }
 

--- a/Observer/BeforeTrackPageViewObserver.php
+++ b/Observer/BeforeTrackPageViewObserver.php
@@ -53,6 +53,7 @@ class BeforeTrackPageViewObserver implements ObserverInterface
      * @param \Magento\Framework\Event\Observer $observer
      * @return \Chessio\Matomo\Observer\BeforeTrackPageViewObserver
      */
+    #[\Override]
     public function execute(\Magento\Framework\Event\Observer $observer)
     {
         $tracker = $observer->getEvent()->getTracker();

--- a/Observer/CartViewObserver.php
+++ b/Observer/CartViewObserver.php
@@ -85,6 +85,7 @@ class CartViewObserver implements ObserverInterface
      * @return \Chessio\Matomo\Observer\CartViewObserver
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
+    #[\Override]
     public function execute(\Magento\Framework\Event\Observer $observer)
     {
         if ($this->_dataHelper->isTrackingEnabled()) {

--- a/Observer/CategoryViewObserver.php
+++ b/Observer/CategoryViewObserver.php
@@ -64,6 +64,7 @@ class CategoryViewObserver implements ObserverInterface
      * @param \Magento\Framework\Event\Observer $observer
      * @return \Chessio\Matomo\Observer\CategoryViewObserver
      */
+    #[\Override]
     public function execute(\Magento\Framework\Event\Observer $observer)
     {
         if (!$this->_dataHelper->isTrackingEnabled()) {

--- a/Observer/CheckoutSuccessObserver.php
+++ b/Observer/CheckoutSuccessObserver.php
@@ -95,6 +95,7 @@ class CheckoutSuccessObserver implements ObserverInterface
      * @param \Magento\Framework\Event\Observer $observer
      * @return \Chessio\Matomo\Observer\CheckoutSuccessObserver
      */
+    #[\Override]
     public function execute(\Magento\Framework\Event\Observer $observer)
     {
         $orderIds = $observer->getEvent()->getOrderIds();

--- a/Observer/ProductViewObserver.php
+++ b/Observer/ProductViewObserver.php
@@ -64,6 +64,7 @@ class ProductViewObserver implements ObserverInterface
      * @param \Magento\Framework\Event\Observer $observer
      * @return \Chessio\Matomo\Observer\ProductViewObserver
      */
+    #[\Override]
     public function execute(\Magento\Framework\Event\Observer $observer)
     {
         if (!$this->_dataHelper->isTrackingEnabled()) {

--- a/Observer/SearchResultObserver.php
+++ b/Observer/SearchResultObserver.php
@@ -86,6 +86,7 @@ class SearchResultObserver implements ObserverInterface
      * @return \Chessio\Matomo\Observer\SearchResultObserver
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
+    #[\Override]
     public function execute(\Magento\Framework\Event\Observer $observer)
     {
         if (!$this->_dataHelper->isTrackingEnabled()) {

--- a/Test/Unit/CustomerData/Checkout/CartPluginTest.php
+++ b/Test/Unit/CustomerData/Checkout/CartPluginTest.php
@@ -77,6 +77,7 @@ class CartPluginTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
+    #[\Override]
     public function setUp(): void
     {
         $className = \Chessio\Matomo\CustomerData\Checkout\CartPlugin::class;

--- a/Test/Unit/CustomerData/Customer/CustomerPluginTest.php
+++ b/Test/Unit/CustomerData/Customer/CustomerPluginTest.php
@@ -77,6 +77,7 @@ class CustomerPluginTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
+    #[\Override]
     public function setUp(): void
     {
         $className = \Chessio\Matomo\CustomerData\Customer\CustomerPlugin::class;

--- a/Test/Unit/Helper/DataTest.php
+++ b/Test/Unit/Helper/DataTest.php
@@ -57,6 +57,7 @@ class DataTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
+    #[\Override]
     public function setUp(): void
     {
         $className = \Chessio\Matomo\Helper\Data::class;

--- a/Test/Unit/Helper/TrackerTest.php
+++ b/Test/Unit/Helper/TrackerTest.php
@@ -49,6 +49,7 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
+    #[\Override]
     public function setUp(): void
     {
         $objectManager = new ObjectManager($this);
@@ -69,12 +70,10 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
         $arguments['actionFactory']
             ->expects($this->any())
             ->method('create')
-            ->willReturnCallback(function ($data) {
-                return new \Chessio\Matomo\Model\Tracker\Action(
-                    $data['name'],
-                    $data['args']
-                );
-            });
+            ->willReturnCallback(fn($data) => new \Chessio\Matomo\Model\Tracker\Action(
+                $data['name'],
+                $data['args']
+            ));
         $this->_tracker = $objectManager->getObject($class, $arguments);
     }
 
@@ -118,7 +117,7 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
         // Build expected tracker result from $items and $total
         $expectedResult = [];
         foreach ($items as $item) {
-            list($sku, $name, $price, $qty) = $item;
+            [$sku, $name, $price, $qty] = $item;
             $expectedResult[] = [
                 'addEcommerceItem',
                 $sku,
@@ -212,8 +211,7 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
     {
         $orders = [];
         foreach ($ordersData as $orderData) {
-            list($incrementId, $grandTotal, $subTotal, $tax, $shipping,
-                 $discount, $itemsData) = $orderData;
+            [$incrementId, $grandTotal, $subTotal, $tax, $shipping, $discount, $itemsData] = $orderData;
              $orders[] = $this->_getOrderMock(
                  $incrementId,
                  $grandTotal,
@@ -243,7 +241,7 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
     {
         $quoteItems = [];
         foreach ($items as $itemData) {
-            list($sku, $name, $price, $qty) = $itemData;
+            [$sku, $name, $price, $qty] = $itemData;
             $item = $this->createPartialMock(
                 \Magento\Quote\Model\Quote\Item::class,
                 ['getData']
@@ -300,7 +298,7 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
     ) {
         $items = [];
         foreach ($itemsData as $itemData) {
-            list($sku, $name, $price, $qty, $parentId) = $itemData;
+            [$sku, $name, $price, $qty, $parentId] = $itemData;
             $items[] = $this->createConfiguredMock(
                 \Magento\Sales\Api\Data\OrderItemInterface::class,
                 [

--- a/Test/Unit/Model/TrackerTest.php
+++ b/Test/Unit/Model/TrackerTest.php
@@ -50,6 +50,7 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
+    #[\Override]
     public function setUp(): void
     {
         $className = \Chessio\Matomo\Model\Tracker::class;

--- a/Test/Unit/Observer/BeforeTrackPageViewObserverTest.php
+++ b/Test/Unit/Observer/BeforeTrackPageViewObserverTest.php
@@ -70,6 +70,7 @@ class BeforeTrackPageViewObserverTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
+    #[\Override]
     public function setUp(): void
     {
         $className = \Chessio\Matomo\Observer\BeforeTrackPageViewObserver::class;

--- a/Test/Unit/Observer/CartViewObserverTest.php
+++ b/Test/Unit/Observer/CartViewObserverTest.php
@@ -84,6 +84,7 @@ class CartViewObserverTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
+    #[\Override]
     public function setUp(): void
     {
         $className = \Chessio\Matomo\Observer\CartViewObserver::class;

--- a/Test/Unit/Observer/CategoryViewObserverTest.php
+++ b/Test/Unit/Observer/CategoryViewObserverTest.php
@@ -77,6 +77,7 @@ class CategoryViewObserverTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
+    #[\Override]
     public function setUp(): void
     {
         $className = \Chessio\Matomo\Observer\CategoryViewObserver::class;

--- a/Test/Unit/Observer/CheckoutSuccessObserverTest.php
+++ b/Test/Unit/Observer/CheckoutSuccessObserverTest.php
@@ -91,6 +91,7 @@ class CheckoutSuccessObserverTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
+    #[\Override]
     public function setUp(): void
     {
         $objectMgr = new ObjectManager($this);

--- a/Test/Unit/Observer/ProductViewObserverTest.php
+++ b/Test/Unit/Observer/ProductViewObserverTest.php
@@ -84,6 +84,7 @@ class ProductViewObserverTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
+    #[\Override]
     public function setUp(): void
     {
         $className = \Chessio\Matomo\Observer\ProductViewObserver::class;
@@ -192,7 +193,7 @@ class ProductViewObserverTest extends \PHPUnit\Framework\TestCase
                 $sku,
                 $name,
                 // Category should be FALSE if product has no category
-                ($category === null) ? false : $category,
+                $category ?? false,
                 (float) $price
             )
             ->willReturn($this->_trackerMock);

--- a/Test/Unit/Observer/SearchResultObserverTest.php
+++ b/Test/Unit/Observer/SearchResultObserverTest.php
@@ -91,6 +91,7 @@ class SearchResultObserverTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
+    #[\Override]
     public function setUp(): void
     {
         $className = \Chessio\Matomo\Observer\SearchResultObserver::class;

--- a/UserId/Provider/EmailProvider.php
+++ b/UserId/Provider/EmailProvider.php
@@ -50,11 +50,12 @@ class EmailProvider implements ProviderInterface
     /**
      * {@inheritDoc}
      */
+    #[\Override]
     public function getUserId($customerId)
     {
         try {
             return $this->_customerRepository->getById($customerId)->getEmail();
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return false;
         }
     }
@@ -62,6 +63,7 @@ class EmailProvider implements ProviderInterface
     /**
      * {@inheritDoc}
      */
+    #[\Override]
     public function getTitle()
     {
         return __('Customer E-mail');

--- a/UserId/Provider/EntityIdProvider.php
+++ b/UserId/Provider/EntityIdProvider.php
@@ -31,6 +31,7 @@ class EntityIdProvider implements ProviderInterface
     /**
      * {@inheritDoc}
      */
+    #[\Override]
     public function getUserId($customerId)
     {
         return (string) $customerId;
@@ -39,6 +40,7 @@ class EntityIdProvider implements ProviderInterface
     /**
      * {@inheritDoc}
      */
+    #[\Override]
     public function getTitle()
     {
         return __('Customer Entity ID');

--- a/UserId/Provider/Pool.php
+++ b/UserId/Provider/Pool.php
@@ -68,8 +68,6 @@ class Pool
      */
     public function getAllProviders()
     {
-        return array_filter($this->_providers, function ($provider) {
-            return $provider instanceof ProviderInterface;
-        });
+        return array_filter($this->_providers, fn($provider) => $provider instanceof ProviderInterface);
     }
 }

--- a/view/frontend/templates/matomo.phtml
+++ b/view/frontend/templates/matomo.phtml
@@ -19,8 +19,10 @@
  * along with Chessio_Matomo.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+/** @var \Chessio\Matomo\Block\Matomo $block */
+/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
-<?php /** @var \Chessio\Matomo\Block\Matomo $block */ ?>
+<?php  ?>
 <script type="text/x-magento-init">
 <?= $block->jsonEncode([
     '*' => [
@@ -29,26 +31,30 @@
 ]); ?>
 </script>
 <?php
+// Render tage without echo so it's added to the dynamic CSP.
+$secureRenderer->renderTag('script', ['src' => $block->getScriptUrl()]);
+
 // The following script can be omitted in which case the
 // `Chessio_Matomo/js/tracker' component will inject the tracker script instead.
 // However that might cause the tracker script to miss the `DOMContentLoaded'
 // event which breaks the link tracking feature.
-?>
-<script type="text/javascript">
+$scriptString = <<<script
 (function (w, d) {
     w._paq = w._paq || [];
-    w._paq.push(['setTrackerUrl', '<?= $block->escapeJsQuote($block->getTrackerUrl()); ?>']);
-    w._paq.push(['setSiteId', <?= (int) $block->getSiteId(); ?>]);
+    w._paq.push(['setTrackerUrl', '{$block->escapeJsQuote($block->getTrackerUrl())}']);
+    w._paq.push(['setSiteId', {$block->getSiteId()}]);
     var g = d.createElement('script'),
         s = d.getElementsByTagName('script')[0];
     g.type = 'text/javascript';
     g.async = true;
     g.defer = true;
-    g.src = '<?= $block->escapeJsQuote($block->getScriptUrl()); ?>';
+    g.src = '{$block->escapeJsQuote($block->getScriptUrl())}';
     s.parentNode.insertBefore(g, s);
 })(window, document);
-</script>
-<?php
+script;
+
+echo $secureRenderer->renderTag('script', [], $scriptString, false);
+
 // The following script is a workaround that prevents the checkout loader
 // overlay from spinning indefinitely in cases where a browser plugin such as
 // AdBlock stops the tracker JS component from loading. The loader indicator
@@ -56,8 +62,8 @@
 // export a mocked version of the component if we get an `errback' from require.
 // @see vendor/magento/module-checkout/view/frontend/web/js/checkout-loader.js
 // @see lib/web/mage/requirejs/resolver.js
-?>
-<script type="text/javascript">
+
+$scriptString = <<<script
 (function (require, undefined) {
     'use strict';
     var moduleName = 'Chessio_Matomo/js/tracker';
@@ -83,7 +89,9 @@
         }
     });
 })(require);
-</script>
+script;
+echo $secureRenderer->renderTag('script', [], $scriptString, false);
+?>
 <noscript>
     <p>
         <img src="<?= $block->getTrackingPixelUrl(); ?>"

--- a/view/frontend/templates/matomo.phtml
+++ b/view/frontend/templates/matomo.phtml
@@ -31,7 +31,7 @@
 ]); ?>
 </script>
 <?php
-// Render tage without echo so it's added to the dynamic CSP.
+// Render tag without echo so it's added to the dynamic CSP.
 $secureRenderer->renderTag('script', ['src' => $block->getScriptUrl()]);
 
 // The following script can be omitted in which case the

--- a/view/frontend/web/js/tracker.js
+++ b/view/frontend/web/js/tracker.js
@@ -94,12 +94,13 @@ define([
      *
      * @param {String} scriptUrl
      */
-    function injectScript(scriptUrl) {
+    function injectScript(scriptUrl, nonce) {
         $('<script>')
             .attr('type', 'text/javascript')
             .attr('async', true)
             .attr('defer', true)
             .attr('src', scriptUrl)
+            .attr('nonce', nonce)
             .appendTo('head');
     }
 
@@ -312,7 +313,7 @@ define([
                     ['setSiteId', defaultSiteId],
                     ['setTrackerUrl', defaultTrackerUrl]
                 ]);
-                injectScript(options.scriptUrl);
+                injectScript(options.scriptUrl, options.nonce);
             }
         } else {
             // If we already have the Matomo object we can resolve any pending


### PR DESCRIPTION
Fixes #59 
Unusable in newer Magento without these changes. 
Using the nonce in tracker.js in only needed if the matomo is running on the same domain, which I am but probably isn't so common. 
